### PR TITLE
Add `row()`

### DIFF
--- a/lib/Math/Matrix/MaybeGSL.pm
+++ b/lib/Math/Matrix/MaybeGSL.pm
@@ -453,6 +453,13 @@ written by the same back-end that is being used for reading.
 
      my $matrix = Matrix->load("my_matrix.dat");
 
+=method C<row>
+
+Returns the selected row in a matrix as a new matrix object. Note that B<indexes start at 1>
+unlike Perl and some other programming languages.
+
+    my $row = $matrix->row(1);
+
 =head1 OVERLOAD
 
 For now only the matrix multiplication is overloaded, in the usual operator, C<*>.

--- a/lib/Math/Matrix/MaybeGSL.pm
+++ b/lib/Math/Matrix/MaybeGSL.pm
@@ -83,6 +83,7 @@ BEGIN {
                     return scalar(_call(min => @_));
                 };
             },
+            row           => sub { _new(_call(row => $_[0], $_[1]-1)) },
            },
          'Math::MatrixReal' => {
             assign        => sub { _call(assign        => @_); },
@@ -95,6 +96,7 @@ BEGIN {
             read          => sub { _mreal_read($_[1]) },
             max           => sub { _mreal_max($_[0]{matrix}) },
             min           => sub { _mreal_min($_[0]{matrix}) },
+            row           => sub { _new( $_[0]{matrix}->row($_[1]) ) },
                                },
 	);
 

--- a/t/tests.pl
+++ b/t/tests.pl
@@ -1,6 +1,6 @@
 #!perl
 
-use Test::More tests => 67;
+use Test::More tests => 71;
 use Math::Matrix::MaybeGSL;
 
 my $m = Matrix->new(10, 20);
@@ -120,5 +120,14 @@ is $m9->element(1,2), 2;
 is $m9->element(2,2), 4;
 
 unlink "tmp-mat" if -f "tmp-mat";
+
+my $m10 = Matrix->new_from_rows( [[1, 2], [3, 4]]);
+isa_ok($m10, 'Math::Matrix::MaybeGSL');
+
+my $m11 = $m10->row(1);
+isa_ok($m11, 'Math::Matrix::MaybeGSL');
+
+is $m11->element(1,1), 1;
+is $m11->element(1,2), 2;
 
 1;


### PR DESCRIPTION
This PR implements `row()` method to select a row in a matrix and return it as new matrix object. Both `Math::MatrixReal` and `Math::GSL::Matrix` has methods of the same name and same function.