### PR TITLE
Add `find_zeros()`

### DIFF
--- a/lib/Math/Matrix/MaybeGSL.pm
+++ b/lib/Math/Matrix/MaybeGSL.pm
@@ -491,6 +491,13 @@ unlike Perl and some other programming languages.
 
     my $row = $matrix->row(1);
 
+=method C<find_zeros>
+
+Given a matrix, returns a nested list of indices corresponding to zero values in the
+given matrix. Note that B<indexes start at 1> unlike Perl and some other programming languages.
+
+    my @indices = $matrix->find_zeros();
+
 =head1 OVERLOAD
 
 For now only the matrix multiplication is overloaded, in the usual operator, C<*>.

--- a/lib/Math/Matrix/MaybeGSL.pm
+++ b/lib/Math/Matrix/MaybeGSL.pm
@@ -84,6 +84,7 @@ BEGIN {
                 };
             },
             row           => sub { _new(_call(row => $_[0], $_[1]-1)) },
+            find_zeros    => sub { _gsl_find_zeros(@_) },
            },
          'Math::MatrixReal' => {
             assign        => sub { _call(assign        => @_); },
@@ -97,6 +98,7 @@ BEGIN {
             max           => sub { _mreal_max($_[0]{matrix}) },
             min           => sub { _mreal_min($_[0]{matrix}) },
             row           => sub { _new( $_[0]{matrix}->row($_[1]) ) },
+            find_zeros    => sub { _mreal_find_zeros(@_) },
                                },
 	);
 
@@ -250,6 +252,20 @@ sub _mreal_read {
     return _new( Math::MatrixReal->new_from_rows($m) );
 }
 
+sub _mreal_find_zeros {
+    my ($matrix) = @_;
+    my ($rs, $cs) = $matrix->dim();
+
+    my @matches;
+    my $pos = 0;
+    for ($matrix->as_list()) {
+        push @matches, [int($pos/$rs)+1, ($pos % $rs)+1] unless $_;
+        $pos++;
+    }
+
+    return @matches;
+}
+
 sub _gsl_read {
     my $filename = shift;
 
@@ -296,6 +312,21 @@ sub _gsl_write {
 
     Math::GSL::gsl_fclose($fh);
 
+}
+
+sub _gsl_find_zeros {
+    my ($matrix) = @_;
+    my ($rs, $cs) = $matrix->dim();
+
+    my $raw_matrix = $matrix->{matrix}->raw;
+    my @matches;
+    for my $i (0..$rs-1) {
+        for my $j (0..$cs-1) {
+            next if Math::GSL::Matrix::gsl_matrix_get($raw_matrix, $i, $j);
+            push @matches, [$i+1, $j+1];
+        }
+    }
+    return @matches;
 }
 
 

--- a/t/tests.pl
+++ b/t/tests.pl
@@ -1,6 +1,6 @@
 #!perl
 
-use Test::More tests => 71;
+use Test::More tests => 79;
 use Math::Matrix::MaybeGSL;
 
 my $m = Matrix->new(10, 20);
@@ -129,5 +129,18 @@ isa_ok($m11, 'Math::Matrix::MaybeGSL');
 
 is $m11->element(1,1), 1;
 is $m11->element(1,2), 2;
+
+my $m12 = Matrix->new_from_rows( [[0, 0], [0, 1]]);
+isa_ok($m12, 'Math::Matrix::MaybeGSL');
+
+my @zeros = $m12->find_zeros();
+
+is scalar(@zeros), 3;
+is $zeros[0]->[0], 1;
+is $zeros[0]->[1], 1;
+is $zeros[1]->[0], 1;
+is $zeros[1]->[1], 2;
+is $zeros[2]->[0], 2;
+is $zeros[2]->[1], 1;
 
 1;


### PR DESCRIPTION
In my project I need an effective way to find all zero-value elements in a quite large matrix. I tried iterating through `as_list()` and then deriving indices for zero-value elements, but that did not fare well with GSL back-end. In addition, `element()` as well adds some overhead. This PR implements the most effective solution I was able to find.

Let me know should the method be named more appropriately.