### PR TITLE
Fix find_zeros() in non-square matrices

### DIFF
--- a/lib/Math/Matrix/MaybeGSL.pm
+++ b/lib/Math/Matrix/MaybeGSL.pm
@@ -259,7 +259,7 @@ sub _mreal_find_zeros {
     my @matches;
     my $pos = 0;
     for ($matrix->as_list()) {
-        push @matches, [int($pos/$rs)+1, ($pos % $rs)+1] unless $_;
+        push @matches, [int($pos/$cs)+1, ($pos % $cs)+1] unless $_;
         $pos++;
     }
 

--- a/t/tests.pl
+++ b/t/tests.pl
@@ -1,6 +1,6 @@
 #!perl
 
-use Test::More tests => 79;
+use Test::More tests => 81;
 use Math::Matrix::MaybeGSL;
 
 my $m = Matrix->new(10, 20);
@@ -130,17 +130,19 @@ isa_ok($m11, 'Math::Matrix::MaybeGSL');
 is $m11->element(1,1), 1;
 is $m11->element(1,2), 2;
 
-my $m12 = Matrix->new_from_rows( [[0, 0], [0, 1]]);
+my $m12 = Matrix->new_from_rows( [[0, 0, 1], [0, 1, 0]]);
 isa_ok($m12, 'Math::Matrix::MaybeGSL');
 
 my @zeros = $m12->find_zeros();
 
-is scalar(@zeros), 3;
+is scalar(@zeros), 4;
 is $zeros[0]->[0], 1;
 is $zeros[0]->[1], 1;
 is $zeros[1]->[0], 1;
 is $zeros[1]->[1], 2;
 is $zeros[2]->[0], 2;
 is $zeros[2]->[1], 1;
+is $zeros[3]->[0], 2;
+is $zeros[3]->[1], 3;
 
 1;


### PR DESCRIPTION
I made a mistake in `Math::MatrixReal` version of `find_zeros()` by switching matrix dimensions. The bug manifests only in non-square matrices (where dimensions are unequal). This PR fixes the bug and extends a test case to cover non-square matrices.